### PR TITLE
Capture trailing parentheses and quotation marks in when separating sentences.

### DIFF
--- a/src/AtelierTomato.Markov.Core/SentenceParser.cs
+++ b/src/AtelierTomato.Markov.Core/SentenceParser.cs
@@ -10,15 +10,16 @@ namespace AtelierTomato.Markov.Core
 	{
 		private readonly Regex sentenceSeparatorPattern = new(@"
 ((?:
-[^.!?\r\n]               # neither sentence punctuation nor newlines
-|                        # nor
-\.\.+                    # ellipses
-|                        # nor
-(?<=\s[!?]*)[!?][!?]+    # questionexciteclusters
-|                        # nor
-[.!?]\w                  # punctuation with word after it
-)+)                      # 1 or multiple
-((\.|[.!?]+)[\)\]}""”«»]*|(|$|\r?\n))", RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
+[^.!?\r\n]                                    # neither sentence punctuation nor newlines
+|                                             # nor
+\.\.+                                         # ellipses
+|                                             # nor
+(?<=\s[!?]*)[!?][!?]+                         # questionexciteclusters
+|                                             # nor
+[.!?]\w                                       # punctuation with word after it
+)+)                                           # 1 or multiple
+((?:\.|[.!?]+)[\)\]}""”«»]*|(?:$|\r?\n))      # capture the sentence ender and any punctuation that should be a part of the same sentence
+		", RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 		private readonly Regex spaceifyEllipsesPattern = new(@"(?<=[^\s.,?!¿¡])([.,?!¿¡])(?=[.,?!¿¡])", RegexOptions.Compiled);
 		private readonly Regex ignoreCountPattern = new(@"^[\p{P}]*$", RegexOptions.Compiled);
 		private readonly Regex deleteLinkPattern = new(@"\S*://\S*", RegexOptions.Compiled);

--- a/src/AtelierTomato.Markov.Core/SentenceParser.cs
+++ b/src/AtelierTomato.Markov.Core/SentenceParser.cs
@@ -18,7 +18,7 @@ namespace AtelierTomato.Markov.Core
 |                        # nor
 [.!?]\w                  # punctuation with word after it
 )+)                      # 1 or multiple
-(\.|[.!?]+|$|\r?\n)", RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
+((\.|[.!?]+)[\)\]}""”«»]*|(|$|\r?\n))", RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 		private readonly Regex spaceifyEllipsesPattern = new(@"(?<=[^\s.,?!¿¡])([.,?!¿¡])(?=[.,?!¿¡])", RegexOptions.Compiled);
 		private readonly Regex ignoreCountPattern = new(@"^[\p{P}]*$", RegexOptions.Compiled);
 		private readonly Regex deleteLinkPattern = new(@"\S*://\S*", RegexOptions.Compiled);
@@ -56,9 +56,10 @@ namespace AtelierTomato.Markov.Core
 		/// </summary>
 		public virtual IEnumerable<string> ParseIntoSentenceTexts(string text)
 		{
-			text = ProcessText(text);
-
+			text = NormalizeEllipses(text);
 			var sentences = SplitIntoSentences(text);
+
+			sentences = sentences.Select(ProcessText);
 			sentences = sentences.Select(SpaceifyEllipses);
 
 			var tokenizedSentences = sentences.Select(s => TokenizeProcessedSentence(s));

--- a/src/AtelierTomato.Markov.Core/SentenceParser.cs
+++ b/src/AtelierTomato.Markov.Core/SentenceParser.cs
@@ -56,11 +56,11 @@ namespace AtelierTomato.Markov.Core
 		/// </summary>
 		public virtual IEnumerable<string> ParseIntoSentenceTexts(string text)
 		{
+			// Called to ensure that spaced ellipses are included in the same sentence and not split.
 			text = NormalizeEllipses(text);
 			var sentences = SplitIntoSentences(text);
 
 			sentences = sentences.Select(ProcessText);
-			sentences = sentences.Select(SpaceifyEllipses);
 
 			var tokenizedSentences = sentences.Select(s => TokenizeProcessedSentence(s));
 			// Remove sentences where the minimum length of the sentence (not including punctuation) is less than the minimum input length for a sentence.
@@ -90,7 +90,9 @@ namespace AtelierTomato.Markov.Core
 			text = SplitOffApostropheSequences(text);
 			text = SplitOffDashSequences(text);
 
+			// This is called again because ProcessDetachCharacters splits up ellipses. 
 			text = NormalizeEllipses(text);
+			text = SpaceifyEllipses(text);
 			return text;
 		}
 

--- a/tests/AtelierTomato.Markov.Core.Test/SentenceParserTests.cs
+++ b/tests/AtelierTomato.Markov.Core.Test/SentenceParserTests.cs
@@ -145,5 +145,25 @@ Life in the Vault is about to change.";
 
 			result.Should().ContainSingle().And.Contain(output);
 		}
+
+		[Theory]
+		[InlineData("(this is a sentence in parentheses.) This is sentence number two", new string[] { "( this is a sentence in parentheses . )", "This is sentence number two" })]
+		[InlineData("[this is a sentence in brackets.] This is sentence number two", new string[] { "[ this is a sentence in brackets . ]", "This is sentence number two" })]
+		[InlineData("{this is a sentence in curly braces.} This is sentence number two", new string[] { "{ this is a sentence in curly braces . }", "This is sentence number two" })]
+		[InlineData("\"this is a sentence in quotes.\" This is sentence number two", new string[] { "\" this is a sentence in quotes . \"", "This is sentence number two" })]
+		[InlineData("»this is a sentence in quotes.« This is sentence number two", new string[] { "» this is a sentence in quotes . «", "This is sentence number two" })]
+		[InlineData("«this is a sentence in quotes.» This is sentence number two", new string[] { "« this is a sentence in quotes . »", "This is sentence number two" })]
+		[InlineData("“this is a sentence in quotes.” This is sentence number two", new string[] { "“ this is a sentence in quotes . ”", "This is sentence number two" })]
+		[InlineData("[(this is a sentence in multiple closers.)] This is sentence number two", new string[] { "[ ( this is a sentence in multiple closers . ) ]", "This is sentence number two" })]
+		[InlineData("(this is a sentence in parentheses. ) This is sentence number two", new string[] { "( this is a sentence in parentheses .", ") This is sentence number two" })]
+		public void CaptureTrailingPunctuationTests(string input, IEnumerable<string> output)
+		{
+			var options = new SentenceParserOptions();
+			var target = new SentenceParser(Options.Create(options));
+
+			var result = target.ParseIntoSentenceTexts(input);
+
+			result.Should().BeEquivalentTo(output);
+		}
 	}
 }

--- a/tests/AtelierTomato.Markov.Service.Discord.Test/DiscordSentenceParserTest.cs
+++ b/tests/AtelierTomato.Markov.Service.Discord.Test/DiscordSentenceParserTest.cs
@@ -459,5 +459,26 @@ Life in the Vault is about to change.";
 
 			result.Should().ContainSingle().And.Contain(output);
 		}
+
+		[Theory]
+		[InlineData("(this is a sentence in parentheses.) This is sentence number two", new string[] { "( this is a sentence in parentheses . )", "This is sentence number two" })]
+		[InlineData("[this is a sentence in brackets.] This is sentence number two", new string[] { "[ this is a sentence in brackets . ]", "This is sentence number two" })]
+		[InlineData("{this is a sentence in curly braces.} This is sentence number two", new string[] { "{ this is a sentence in curly braces . }", "This is sentence number two" })]
+		[InlineData("\"this is a sentence in quotes.\" This is sentence number two", new string[] { "\" this is a sentence in quotes . \"", "This is sentence number two" })]
+		[InlineData("»this is a sentence in quotes.« This is sentence number two", new string[] { "» this is a sentence in quotes . «", "This is sentence number two" })]
+		[InlineData("«this is a sentence in quotes.» This is sentence number two", new string[] { "« this is a sentence in quotes . »", "This is sentence number two" })]
+		[InlineData("“this is a sentence in quotes.” This is sentence number two", new string[] { "“ this is a sentence in quotes . ”", "This is sentence number two" })]
+		[InlineData("[(this is a sentence in multiple closers.)] This is sentence number two", new string[] { "[ ( this is a sentence in multiple closers . ) ]", "This is sentence number two" })]
+		[InlineData("(this is a sentence in parentheses. ) This is sentence number two", new string[] { "( this is a sentence in parentheses .", ") This is sentence number two" })]
+		public void CaptureTrailingPunctuationTests(string input, IEnumerable<string> output)
+		{
+			var options = new SentenceParserOptions();
+			var discordOptions = new DiscordSentenceParserOptions();
+			var target = new DiscordSentenceParser(Options.Create(options), Options.Create(discordOptions));
+
+			var result = target.ParseIntoSentenceTexts(input);
+
+			result.Should().BeEquivalentTo(output);
+		}
 	}
 }


### PR DESCRIPTION
Basically `(This is a sentence.) This is sentence 2.` was previously split into `( This is a sentence .` and `) This is sentence 2 .`
This makes it split into ` ( This is a sentence . )` and `This is sentence 2 .` instead.